### PR TITLE
support comments in PKGBUILDs

### DIFF
--- a/customizepkg
+++ b/customizepkg
@@ -145,7 +145,7 @@ if [ ! -r ./PKGBUILD ]; then
 fi
 
 # use eval instead of creating a temp file to get pkgname etc
-eval $(grep -E '^[[:blank:]]*_?(pkg.*|name)=' ./PKGBUILD | sed 's/#.*//')
+eval $(grep -Po '^[[:blank:]]*_?(pkg.*|name)=[^#]*(?= *#|$)' ./PKGBUILD)
 
 # copy for modification
 cp ./PKGBUILD ./PKGBUILD.custom


### PR DESCRIPTION
To access variables like `$pkgname` or `$pkgbase` from the `PKGBUILD`, parts of it are extracted by `grep` and then executed using `eval`.  When one of the extracted lines contains a hash (`#`), every following line will be regarded as a comment by `eval` and thus be discarded. This prevents correct function with some packages, for example `linux`, or `linux-headers`, generated [from the kernel `PKGBUILD`](https://projects.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/linux).

Removing the comments before evaluation fixes this.
