### PR TITLE
Use absolute path for patch files

### DIFF
--- a/customizepkg
+++ b/customizepkg
@@ -120,9 +120,9 @@ modify_file()
 				elif [[ -f "${pattern}" || -f "${CONFIGDIR}/${package}.files/${pattern}" ]]; then
 					echo "=> apply patch ${pattern} using '-p${context}'"
 					if grep -q '^[[:blank:]]*prepare()' "${scriptfile}"; then
-						sed -i "/^[[:blank:]]*prepare()/{n;s%$%\npatch -Np${context} -i ${pattern}%;}" "${scriptfile}"
+						sed -i "/^[[:blank:]]*prepare()/{n;s%$%\npatch -Np${context} -i \$srcdir/${pattern}%;}" "${scriptfile}"
 					else
-						sed -i "/^[[:blank:]]*build()/{n;s%$%\npatch -Np${context} -i ${pattern}%;}" "${scriptfile}"
+						sed -i "/^[[:blank:]]*build()/{n;s%$%\npatch -Np${context} -i \$srcdir/${pattern}%;}" "${scriptfile}"
 					fi
 				else
 					echo "error: file not found '${pattern}'. Try putting it in ${CONFIGDIR}/${package}.files"


### PR DESCRIPTION
Fixes https://github.com/ava1ar/customizepkg/issues/24. Patch by @bartoszek, given in that issue.