### PR TITLE
Fix issue with multiline pkgdesc

### DIFF
--- a/customizepkg
+++ b/customizepkg
@@ -164,7 +164,8 @@ fi
 
 # use eval instead of creating a temp file to get pkgname etc
 # second grep used to filter out all variables with subshell execution like $() or ``
-eval $(grep -Pazo '[^[:print:]][[:blank:]]*_?(pkg.*|name)=(\((.|\n)*?\)|[^#]*?(?= *#|\x0a))' ./PKGBUILD | grep -Eva '\$\(|`')
+# and pkgdesc variable, because multiline description breaks eval execution
+eval $(grep -Pazo '[^[:print:]][[:blank:]]*_?(pkg.*|name)=(\((.|\n)*?\)|[^#]*?(?= *#|\x0a))' ./PKGBUILD | grep -Eva '\$\(|`|pkgdesc')
 
 # copy for modification
 cp ./PKGBUILD ./PKGBUILD.custom


### PR DESCRIPTION
I faced with error when I tried to customize [taskd-git](https://aur.archlinux.org/packages/taskd-git/):

```
/usr/bin/customizepkg: line 167: warning: command substitution: ignored null byte in input
/usr/bin/customizepkg: eval: line 167: unexpected EOF while looking for matching `"'
/usr/bin/customizepkg: eval: line 168: syntax error: unexpected end of file
```

After some digging I found out that the reason is multiline value of `pkgdesc` variable: 

```sh
pkgrel=1
pkgdesc="A lightweight secure server providing multi-user,
 multi-client access to task data"
url='http://tasktools.org/projects/taskd.html'
```

And this string is to be eval'ed:
```sh

pkgname=taskd-git
pkgver=r936.30c5729
pkgrel=1
pkgdesc="A lightweight secure server providing multi-user,
```

So I just exclude `pkgdesc` from list of variables.