### PR TITLE
Use a default checksum context if PKGBUILD doesn't originally have one

### DIFF
--- a/customizepkg
+++ b/customizepkg
@@ -186,6 +186,9 @@ do
 	if [ -d  "${CONFIGDIR}/${package}.files" ]; then
 		# find checksum type used in PKGBUILD and utility to calculate the sum for added files
 		checksum_context=$(grep -om 1 "^[a-z]*[0-9]*sums" "./PKGBUILD")
+		if [ -z "${checksum_context}" ]; then
+			checksum_context="sha256sums";
+		fi
 		checksum_utility=${checksum_context%?}
 		echo "=> files from ${CONFIGDIR}/${package}.files will be included into package "
 		for filepath in ${CONFIGDIR}/${package}.files/*; do


### PR DESCRIPTION
Some packages (e.g. kvantum-tools-qt5-svn) don't have a `source` array, and thus don't have a checksum array either. This results in customizepkg adding a `=('')` to the PKGBUILD if any sources get added, which breaks the package.
Change simply replaces an empty checksum context with `sha256sums` as a default.