### PR TITLE
change the patch commnad to patch the source to descend in the package-version folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ Patch files can be applied to the source code using the following syntax:
 ```
 patch#1#file.patch
 ```
+In the original repo this generate a line in PKGBUILD in `prepare` function:
+
+```
+patch -Np1 -i file.patch
+```
+
+this is modified to generate:
+
+```
+patch -Np1 --directory=$pkgname-$pkgver < file.patch
+```
+this way `makepkg` descends in the `src/` directory and apply the patch `file.patch` in the `$pkgname-$pkgver` directory below.
+
+`$pkgname-$pkgver` are local veriables available in the PKGBUILD.
 
 - The context ("1" above) is the number of leading components to strip (i.e. `patch -p1`)
 - The path cannot contain variables

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ patch -Np1 --directory=$pkgname-$pkgver < file.patch
 ```
 this way `makepkg` descends in the `src/` directory and apply the patch `file.patch` in the `$pkgname-$pkgver` directory below.
 
-`$pkgname-$pkgver` are local veriables available in the PKGBUILD.
+`$pkgname-$pkgver` are local variables available in the PKGBUILD.
 
 - The context ("1" above) is the number of leading components to strip (i.e. `patch -p1`)
 - The path cannot contain variables

--- a/customizepkg
+++ b/customizepkg
@@ -120,10 +120,10 @@ modify_file()
 				elif [[ -f "${pattern}" || -f "${CONFIGDIR}/${package}.files/${pattern}" ]]; then
 					echo "=> apply patch ${pattern} using '-p${context}'"
 					if grep -q '^[[:blank:]]*prepare()' "${scriptfile}"; then
-						sed -i "/^[[:blank:]]*prepare()/{n;s%$%\npatch -Np${context} -i ${pattern}%;}" "${scriptfile}"
-					else
-						sed -i "/^[[:blank:]]*build()/{n;s%$%\npatch -Np${context} -i ${pattern}%;}" "${scriptfile}"
-					fi
+                                                sed -i "/^[[:blank:]]*prepare()/{n;s%$%\n  patch -Np${context} --directory=\"$pkgname-$pkgver\" < ${pattern}%;}" "${scriptfile}"
+                                        else
+                                                sed -i "/^[[:blank:]]*build()/{n;s%$%\n  patch -Np${context}  --directory=\"$pkgname-$pkgver\" < ${pattern}%;}" "${scriptfile}"
+                                        fi
 				else
 					echo "error: file not found '${pattern}'. Try putting it in ${CONFIGDIR}/${package}.files"
 				fi


### PR DESCRIPTION
# Patch the source #

Patch files can be applied to the source code using the following syntax:

```
patch#1#file.patch
```
In the original repo this generate a line in PKGBUILD in `prepare` function:

```
patch -Np1 -i file.patch
```

this is modified to generate:

```
patch -Np1 --directory=$pkgname-$pkgver < file.patch
```
this way `makepkg` descends in the `src/` directory and apply the patch `file.patch` in the `$pkgname-$pkgver` directory below.


