### PR TITLE
Use an absolute patch path

### DIFF
--- a/customizepkg
+++ b/customizepkg
@@ -186,11 +186,10 @@ do
 	#adding new files current dir from  ${CFGDIR}/${package} folder and including them to PKGBUILD
 	if [ -d  "${CONFIGDIR}/${package}.files" ]; then
 		# find checksum type used in PKGBUILD and utility to calculate the sum for added files
-		checksum_context=$(grep -om 1 "^[a-z]*[0-9]*sums" "./PKGBUILD")
-		if [ -z "${checksum_context}" ]; then
-			checksum_context="sha256sums";
+		checksum_contexts=$(grep -o "^[a-z]*[0-9]*sums" "./PKGBUILD")
+		if [ -z "${checksum_contexts}" ]; then
+			checksum_contexts="sha256sums";
 		fi
-		checksum_utility=${checksum_context%?}
 		echo "=> files from ${CONFIGDIR}/${package}.files will be included into package "
 		for filepath in ${CONFIGDIR}/${package}.files/*; do
 			if [[ -f ${filepath} ]]; then
@@ -200,7 +199,11 @@ do
 				if [[ $? -eq 0 ]];
 					then
 						echo "add#source#${filename}" >> ./${package}.customize
-						echo "add#${checksum_context}#$(${checksum_utility} < ./${filename} | cut -d" " -f1)" >> ./${package}.customize
+						for checksum_context in $checksum_contexts
+						do
+							checksum_utility=${checksum_context%?}
+							echo "add#${checksum_context}#$(${checksum_utility} < ./${filename} | cut -d" " -f1)" >> ./${package}.customize
+						done
 						echo 'included'
 					else
 						echo 'already exists. Skipping...'

--- a/customizepkg
+++ b/customizepkg
@@ -120,9 +120,9 @@ modify_file()
 				elif [[ -f "${pattern}" || -f "${CONFIGDIR}/${package}.files/${pattern}" ]]; then
 					echo "=> apply patch ${pattern} using '-p${context}'"
 					if grep -q '^[[:blank:]]*prepare()' "${scriptfile}"; then
-						sed -i "/^[[:blank:]]*prepare()/{n;s%$%\npatch -Np${context} -i ${pattern}%;}" "${scriptfile}"
+						sed -i "/^[[:blank:]]*prepare()/{n;s%$%\npatch -Np${context} -i \${srcdir}/${pattern}%;}" "${scriptfile}"
 					else
-						sed -i "/^[[:blank:]]*build()/{n;s%$%\npatch -Np${context} -i ${pattern}%;}" "${scriptfile}"
+						sed -i "/^[[:blank:]]*build()/{n;s%$%\npatch -Np${context} -i \${srcdir}/${pattern}%;}" "${scriptfile}"
 					fi
 				else
 					echo "error: file not found '${pattern}'. Try putting it in ${CONFIGDIR}/${package}.files"


### PR DESCRIPTION
The directory `cd`'d to at the start of `prepare()` or `build()` can be unexpected. This patch ensures that paths to patches are related to `$srcdir`