### PR TITLE
Remove null byte to silence the error message

### DIFF
--- a/customizepkg
+++ b/customizepkg
@@ -165,7 +165,7 @@ fi
 # use eval instead of creating a temp file to get pkgname etc
 # second grep used to filter out all variables with subshell execution like $() or ``
 # and pkgdesc variable, because multiline description breaks eval execution
-eval $(grep -Pazo '[^[:print:]][[:blank:]]*_?(pkg.*|name)=(\((.|\n)*?\)|[^#]*?(?= *#|\x0a))' ./PKGBUILD | grep -Eva '\$\(|`|pkgdesc')
+eval $(grep -Pazo '[^[:print:]][[:blank:]]*_?(pkg.*|name)=(\((.|\n)*?\)|[^#]*?(?= *#|\x0a))' ./PKGBUILD | grep -Eva '\$\(|`|pkgdesc' | tr -d '\0')
 
 # copy for modification
 cp ./PKGBUILD ./PKGBUILD.custom


### PR DESCRIPTION
Currently every package (passed through paru) generates an error message:
```
/usr/bin/customizepkg: line 168: warning: command substitution: ignored null byte in input
```
This results in quite a noisy output while installing or updating packages.
Turns out the `grep` command, at least used like this, generates a null byte every single time.

This pull request makes a simple change to remove said null byte from its output so `eval` won't complain about it anymore.