### PR TITLE
Add support for PKGBUILDs without leading comment

### DIFF
--- a/customizepkg
+++ b/customizepkg
@@ -165,7 +165,7 @@ fi
 # use eval instead of creating a temp file to get pkgname etc
 # second grep used to filter out all variables with subshell execution like $() or ``
 # and pkgdesc variable, because multiline description breaks eval execution
-eval $(grep -Pazo '[^[:print:]][[:blank:]]*_?(pkg.*|name)=(\((.|\n)*?\)|[^#]*?(?= *#|\x0a))' ./PKGBUILD | grep -Eva '\$\(|`|pkgdesc' | tr -d '\0')
+eval $(grep -Pazo '(^|[^[:print:]])[[:blank:]]*_?(pkg.*|name)=(\((.|\n)*?\)|[^#]*?(?= *#|\x0a))' ./PKGBUILD | grep -Eva '\$\(|`|pkgdesc' | tr -d '\0')
 
 # copy for modification
 cp ./PKGBUILD ./PKGBUILD.custom


### PR DESCRIPTION
The AUR submission guidelines require that a `PKGBUILD` starts with one or more comment lines containing contact info of maintainers and contributors.

The `customizepkg` script relies on that requirement, ignoring the first line of the PKGBUILD. While that works with most packages, it fails with some because they contain `pkgname` or similar relevant declarations in line 1.

Examples for affected packages:

- [1password](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=1password)
- [clang15](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=clang15)
- [compiler-rt15](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=compiler-rt15)
- [python-clang15](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=python-clang15)
- [python-setuptools-git-versioning](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=python-setuptools-git-versioning)

For the first four packages, `customizepkg` ignores the patch altogether because the first line of each of the `PKGBUILD`s contain the `pkgname`.

For `python-setuptools-git-versioning`, `customizepkg` misreads the `pkgname` as `python-`, because the first two lines of its `PKGBUILD` read as follows:

```PKGBUILD
_name=setuptools-git-versioning
pkgname=python-${_name}
```

This PR fixes the regular expression in `customizepkg` that filters the `PKGBUILD` so it now picks up the first line, too.

Fixes #27.
