### PR TITLE
Fix Bash parameter expansion

### DIFF
--- a/customizepkg
+++ b/customizepkg
@@ -165,7 +165,7 @@ fi
 # use eval instead of creating a temp file to get pkgname etc
 # second grep used to filter out all variables with subshell execution like $() or ``
 # and pkgdesc variable, because multiline description breaks eval execution
-eval $(grep -Pazo '(^|[^[:print:]])[[:blank:]]*_?(pkg.*|name)=(\((.|\n)*?\)|[^#]*?(?= *#|\x0a))' ./PKGBUILD | grep -Eva '\$\(|`|pkgdesc' | tr -d '\0')
+eval $(grep -Pazo '(^|[^[:print:]])[[:blank:]]*_?(pkg.*|name)=(\((.|\n)*?\)|.*?(?=( +#)|\x0a))' ./PKGBUILD | grep -Eva '\$\(|`|pkgdesc' | tr -d '\0')
 
 # copy for modification
 cp ./PKGBUILD ./PKGBUILD.custom


### PR DESCRIPTION
Bash has a feature called [parameter expansion](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html).
PKGBUILDs sometimes use that feature to strip prefixes:

```bash
pkgname="python-foo"
_name=${pkgname#python-}
```

Because the syntax includes a hash sign (`#`), the current version of customizepkg’s regex pattern misinterprets usage of this feature as a line comment:

```plain

[^#]*?(?= *#|\x0a)
^^^^^^               capture the part before the `#` sign
         ^^^         cut off the rest of the line
```

The problem with this pattern is that it interprets the `#` sign as the beginning of a line comment, even if it’s not preceded by a whitespace, including usages of parameter
expansion.
That means the pattern cuts off in the middle of a parameter expansion, causing customizepkg to abort with an error message:

> /usr/bin/customizepkg: eval: line 168: unexpected EOF while looking for matching `}'

Examples for affected packages:

- [discover-overlay](https://github.com/ava1ar/customizepkg/issues/30#issuecomment-2573941949)
- [python-llm](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=python-llm)
- [python-progress](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=python-progress)

This problem has also been mentioned in https://github.com/ava1ar/customizepkg/issues/30#issuecomment-2573941949 (however I think that the comment is unrelated to the multiline problem.)

This PR fixes the issue by requiring at least one whitespace in order to detect the start of a line comment:

```plain

.*?(?=( +#)|\x0a)
^^                   capture as much as we need
      ^^^^^          cut off only if ` #` appears
                     (hash sign preceded by space)
```
