### PR TITLE
patch - prepare() and build() blocks check if first line is using 'cd'

### DIFF
--- a/customizepkg
+++ b/customizepkg
@@ -122,9 +122,17 @@ modify_file()
 				elif [[ -f "${pattern}" || -f "${CONFIGDIR}/${package}.files/${pattern}" ]]; then
 					echo "=> apply patch ${pattern} using '-p${context}'"
 					if grep -q '^[[:blank:]]*prepare()' "${scriptfile}"; then
-						sed -i "/^[[:blank:]]*prepare()/{n;s%$%\npatch -Np${context} -i \${srcdir}/${pattern}%;}" "${scriptfile}"
+						if grep -a1 '^[[:blank:]]*prepare()' "${scriptfile}" | grep -q "cd "; then
+							sed -i "/^[[:blank:]]*prepare()/{n;s%$%\npatch -Np${context} -i \${srcdir}/${pattern}%;}" "${scriptfile}"
+						else
+							sed -i "/^[[:blank:]]*prepare()/{s%$%\npatch -Np${context} -i \${srcdir}/${pattern}%;}" "${scriptfile}"
+						fi
 					else
-						sed -i "/^[[:blank:]]*build()/{n;s%$%\npatch -Np${context} -i \${srcdir}/${pattern}%;}" "${scriptfile}"
+						if grep -a1 '^[[:blank:]]*build()' "${scriptfile}" | grep -q "cd "; then
+							sed -i "/^[[:blank:]]*build()/{n;s%$%\npatch -Np${context} -i \${srcdir}/${pattern}%;}" "${scriptfile}"
+						else
+							sed -i "/^[[:blank:]]*build()/{s%$%\npatch -Np${context} -i \${srcdir}/${pattern}%;}" "${scriptfile}"
+						fi
 					fi
 				else
 					echo "error: file not found '${pattern}'. Try putting it in ${CONFIGDIR}/${package}.files"


### PR DESCRIPTION
Closes https://github.com/ava1ar/customizepkg/issues/42

Additional check ensuring that customizepkg inserts the patch string in the beginning of the `prepare()` or `build()` blocks if there is no command to change directory at the beginning of the block.  

if `cd` appears, behavior will be unchanged.