### PR TITLE
Fix applying profiles to split packages

### DIFF
--- a/customizepkg
+++ b/customizepkg
@@ -193,6 +193,7 @@ eval $(grep -Pazo '(^|[^[:print:]])[[:blank:]]*_?(pkg.*|name)=(\((.|\n)*?\)|.*?(
 
 # copy for modification
 cp ./PKGBUILD ./PKGBUILD.custom
+CUSTOMIZED=0
 
 for package in "${pkgname[@]}"
 do
@@ -264,12 +265,14 @@ do
 
 	# make any changes to PKGBUILD.custom
 	modify_file "./${package}.customize" "./PKGBUILD" "./PKGBUILD.custom" && rm -f "./${package}.customize" || exit 1
-	if [ ${MODIFY} -eq 1 ]; then
-		mv ./PKGBUILD ./PKGBUILD.original
-		mv ./PKGBUILD.custom ./PKGBUILD
-	else
-		rm ./PKGBUILD.custom
-	fi
+	CUSTOMIZED=1
 done
+
+if [ ${CUSTOMIZED} -eq 1 ] && [ ${MODIFY} -eq 1 ]; then
+	mv ./PKGBUILD ./PKGBUILD.original
+	mv ./PKGBUILD.custom ./PKGBUILD
+else
+	rm ./PKGBUILD.custom
+fi
 
 exit 0

--- a/tests/split-packages.sh
+++ b/tests/split-packages.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -eu
+
+CUSTOMIZEPKG=$(realpath "$(dirname "$0")/../customizepkg")
+TESTDIR=$(mktemp -d)
+trap 'rm -rf "$TESTDIR"' EXIT
+
+mkdir -p "$TESTDIR/config"
+cat > "$TESTDIR/PKGBUILD" <<'EOF'
+pkgname=(one two)
+pkgver=1
+EOF
+cp "$TESTDIR/PKGBUILD" "$TESTDIR/expected-original"
+
+cat > "$TESTDIR/config/one" <<'EOF'
+#!/bin/bash
+printf '\n# one\n' >> "$2"
+EOF
+cat > "$TESTDIR/config/two" <<'EOF'
+#!/bin/bash
+printf '\n# two\n' >> "$2"
+EOF
+chmod +x "$TESTDIR/config/one" "$TESTDIR/config/two"
+
+(
+	cd "$TESTDIR"
+	CUSTOMIZEPKG_CONFIG="$TESTDIR/config" "$CUSTOMIZEPKG" --modify --silence
+)
+
+grep -Fxq '# one' "$TESTDIR/PKGBUILD"
+grep -Fxq '# two' "$TESTDIR/PKGBUILD"
+cmp "$TESTDIR/expected-original" "$TESTDIR/PKGBUILD.original"
+test ! -e "$TESTDIR/PKGBUILD.custom"
+
+rm "$TESTDIR/config/one" "$TESTDIR/config/two"
+cp "$TESTDIR/expected-original" "$TESTDIR/PKGBUILD"
+rm "$TESTDIR/PKGBUILD.original"
+
+(
+	cd "$TESTDIR"
+	CUSTOMIZEPKG_CONFIG="$TESTDIR/config" "$CUSTOMIZEPKG" --modify --silence
+)
+
+cmp "$TESTDIR/expected-original" "$TESTDIR/PKGBUILD"
+test ! -e "$TESTDIR/PKGBUILD.custom"


### PR DESCRIPTION
Apply all configured split-package profiles to the same working PKGBUILD instead of replacing the working copy during each loop iteration. Finalize or remove PKGBUILD.custom once after processing every package. This also prevents an unused PKGBUILD.custom from remaining when no configuration matches.

Adds regression coverage for multiple configured split packages, preservation of PKGBUILD.original, and no-config cleanup.